### PR TITLE
Added relative path support from the workspace root.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ out
 node_modules
 *.vsix
 node_modules
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "copy"
   ],
   "repository": {
-		"type": "git",
-		"url": "https://github.com/mightycoco/fsdeploy.git"
-	},
+    "type": "git",
+    "url": "https://github.com/mightycoco/fsdeploy.git"
+  },
   "galleryBanner": {
     "color": "#9ebeff",
     "theme": "dark"
@@ -45,22 +45,22 @@
         "category": "fsdeploy"
       }
     ],
-	"configuration": {
-		"type":"object",
-		"title":"fsdeploy Configuration",
-		"properties": {
-			"fsdeploy.nodes": {
-				"type": "array",
-				"default": [],
-				"description": "An array of objects containing a source/target set. Each array item is an object: {source: string, target: string, include: glob, exclude: glob}"
-			},
-			"fsdeploy.deployOnSave": {
-				"type": "boolean",
-				"default": true,
-				"description": "A boolean flag indicating if a file should get immeadiately deployed when saving"
-			}
-		}
-	}
+    "configuration": {
+      "type": "object",
+      "title": "fsdeploy Configuration",
+      "properties": {
+        "fsdeploy.nodes": {
+          "type": "array",
+          "default": [],
+          "description": "An array of objects containing a source/target set. Each array item is an object: {source: string, target: string, include: glob, exclude: glob}"
+        },
+        "fsdeploy.deployOnSave": {
+          "type": "boolean",
+          "default": true,
+          "description": "A boolean flag indicating if a file should get immeadiately deployed when saving"
+        }
+      }
+    }
   },
   "icon": "logo.svg",
   "scripts": {

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,14 @@
+{
+    "defaultSeverity": "warning",
+    "rules": {
+      "indent": [
+        true,
+        "spaces",
+        4
+      ],
+      "quotemark": [
+        true,
+        "single"
+      ]
+    }
+  }


### PR DESCRIPTION
Completed support for relative paths to fix issue  #5.  Example:

```json
{
    "fsdeploy.nodes": [
        { 
            "source": "./shared",
            "target": "../another-project/shared",
            "include": "**/*.*"
        }
    ]
}
```