### PR TITLE
feat: add notInWorkspace flag and source support subdir in workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,10 @@
 								"type": "boolean",
 								"description": "Remove the target folder on deployment"
 							},
+							"notInWorkspace": {
+								"type": "boolean",
+								"description": "If true, the source folder is not in the workspace"
+							},
 							"scp": {
 								"type": "object",
 								"title": "Configuration for SCP if target is a linux system",

--- a/src/fsconfignode.ts
+++ b/src/fsconfignode.ts
@@ -5,6 +5,7 @@ interface fsConfigNode {
     target: string;
     exclude: string;
     include: string;
+    notInWorkspace: boolean;
 	deleteTargetOnDeploy: boolean;
 	deployWorkspaceOnSave: boolean;
     scp: {

--- a/src/fsdeploy.ts
+++ b/src/fsdeploy.ts
@@ -125,6 +125,10 @@ function getWorkspaceDeployNodes(): fsConfigNode[] {
 	let nodes: fsConfigNode[] = vscode.workspace.getConfiguration('fsdeploy').get("nodes", []);
 	let fsnodes: fsConfigNode[] = [];
 	nodes.forEach((node: fsConfigNode) => {
+		if (node.notInWorkspace) {
+			fsnodes.push(node);
+			return;
+		}
 		const sourcePath = getAbsolutePath(node.source);
 		if (sourcePath.toLowerCase().startsWith(getWorkspaceRootPath().toLowerCase())) {
 			fsnodes.push(node);
@@ -259,7 +263,7 @@ async function deployWorkspace(): Promise<void> {
 					}
 				}
 
-				var files = await vscode.workspace.findFiles(node.include, node.exclude);
+				var files = await vscode.workspace.findFiles(new vscode.RelativePattern(node.source, node.include), node.exclude);
 				overall_items += files.length;
 				for (const file of files) {
 					if (file.scheme == "file") {


### PR DESCRIPTION
If notInWorkspace is true, means the source folder is not in the workspace.